### PR TITLE
Remove RpmGetSrpm and just provide RpmSpecFromFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,16 @@ seem to correctly parse all macros.
 
 ## Library
 
-Given a URL to a src rpm, downloads to the output location directly into the 
-rpmbuild build structure i.e. /tmp/SRPM. Also parses the specfile and makes
-those fields available in an `RpmSpec` struct
+Given a path to a local file it extracts the SRPM in the output directory and
+parses the specfile and makes those fields available in an `RpmSpec` struct
 ```go
-RpmGetSrcRpm("http://ftp.iinet.net.au/pub/fedora/linux/updates/34/Modular/SRPMS/Packages/c/cri-o-1.20.0-1.module_f34+10489+4277ba4d.src.rpm", "/tmp/")
+RpmSpecFromFile("cri-o-1.20.0-1.module_f34+10489+4277ba4d.src.rpm", "/tmp/")
 ```
 
 Attempt to work out which field in the specfile is `source0`:
 
 ```go
-source0, _ := r.RpmGetSource0()
+source0, _ := r.GetSource0()
 ```
 
 Get license information: 
@@ -33,15 +32,15 @@ r.Tags["license"]
 Apply any patches associated in the source rpm:
 
 ```go
-if err := r.RpmApplyPatches(); err != nil {
+if err := r.ApplyPatches(); err != nil {
     fmt.Println(err.Error())
 }
 ```
 
-Cleanup any rpmbuild build folders, i.e. reset state before `RpmGetSrcRpm`
+Cleanup any rpmbuild build folders, i.e. reset state before `RpmSpecFromFile`
 
 ```go
-r.RpmCleanup()
+r.Cleanup()
 ```
 
 ## Dev container

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ applying any patch files found.
 
 The tool `rpmbuild` must be installed. I didn't want to recreate what `rpmbuild`
 or `rpmspec` does, especially parsing specfiles, and `python-rpm-spec` didn't
-seem to correctly parse all marcos. 
+seem to correctly parse all macros.
 
 ## Library
 

--- a/cmd/rpmtools/rpmtools.go
+++ b/cmd/rpmtools/rpmtools.go
@@ -3,12 +3,16 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
 
 	"github.com/mcoops/rpmtools"
 )
 
 func main() {
-	urlPtr := flag.String("srpm", "", "url to download and patch specfile, i.e. http://ftp.iinet.net.au/pub/fedora/linux/updates/34/Modular/SRPMS/Packages/c/cri-o-1.20.0-1.module_f34+10489+4277ba4d.src.rpm")
+	urlPtr := flag.String("srpm", "", "url/filepath to download and patch specfile, i.e. http://ftp.iinet.net.au/pub/fedora/linux/updates/34/Modular/SRPMS/Packages/c/cri-o-1.20.0-1.module_f34+10489+4277ba4d.src.rpm")
 
 	flag.Parse()
 
@@ -17,8 +21,36 @@ func main() {
 		return
 	}
 
-	r, err := rpmtools.RpmGetSrpm(*urlPtr, "/tmp/")
+	var filePath string
+	if strings.HasPrefix(*urlPtr, "file://") {
+		filePath = (*urlPtr)[len("file://"):]
+	} else if strings.HasPrefix(*urlPtr, "http://") || strings.HasPrefix(*urlPtr, "https://") {
+		resp, err := http.Get(*urlPtr)
+		if err != nil {
+			fmt.Println("Could not download the srpm")
+			return
+		}
+		defer resp.Body.Close()
 
+		out, err := ioutil.TempFile("", "")
+		if err != nil {
+			fmt.Println("Could not download the srpm")
+			return
+		}
+		defer out.Close()
+
+		_, err = io.Copy(out, resp.Body)
+		if err != nil {
+			fmt.Println("Could not download the srpm")
+			return
+		}
+		filePath = out.Name()
+	} else {
+		fmt.Println("srpm flag should start with file:// or http(s)://")
+		return
+	}
+
+	r, err := rpmtools.RpmSpecFromFile(filePath, "/tmp")
 	if err != nil {
 		fmt.Printf("%s", err.Error())
 	}
@@ -27,6 +59,15 @@ func main() {
 	fmt.Println("Source0: " + source0)
 	fmt.Printf("Licenses: ")
 	fmt.Println(r.Tags["license"])
+	fmt.Println("SpecLocation: " + r.SpecLocation)
+	fmt.Println("SRPMLocation: " + r.SrpmLocation)
+	fmt.Println("SourcesLocation: " + r.SourcesLocation)
+	fmt.Println("OutLocation: " + r.OutLocation)
+	fmt.Println("BuildLocation: " + r.BuildLocation)
+
+	for name, tag := range r.Tags {
+		fmt.Printf("Tag %s = %s\n", name, tag)
+	}
 
 	if err := r.RpmApplyPatches(); err != nil {
 		fmt.Println(err.Error())

--- a/cmd/rpmtools/rpmtools.go
+++ b/cmd/rpmtools/rpmtools.go
@@ -13,6 +13,7 @@ import (
 
 func main() {
 	urlPtr := flag.String("srpm", "", "url/filepath to download and patch specfile, i.e. http://ftp.iinet.net.au/pub/fedora/linux/updates/34/Modular/SRPMS/Packages/c/cri-o-1.20.0-1.module_f34+10489+4277ba4d.src.rpm")
+	noCleanup := flag.Bool("nocleanup", false, "does not clean up the RPM directories at the end")
 
 	flag.Parse()
 
@@ -55,7 +56,7 @@ func main() {
 		fmt.Printf("%s", err.Error())
 	}
 
-	source0, _ := r.RpmGetSource0()
+	source0, _ := r.GetSource0()
 	fmt.Println("Source0: " + source0)
 	fmt.Printf("Licenses: ")
 	fmt.Println(r.Tags["license"])
@@ -69,9 +70,11 @@ func main() {
 		fmt.Printf("Tag %s = %s\n", name, tag)
 	}
 
-	if err := r.RpmApplyPatches(); err != nil {
+	if err := r.ApplyPatches(); err != nil {
 		fmt.Println(err.Error())
 	}
 
-	r.RpmCleanup()
+	if !*noCleanup {
+		r.Cleanup()
+	}
 }

--- a/rpmtools.go
+++ b/rpmtools.go
@@ -103,7 +103,7 @@ func rpmCleanSpecFile(name string) error {
 
 // Given a directory to scan, find the first file ending with .spec
 
-func RpmFindSpec(dir string) (string, error) {
+func rpmFindSpec(dir string) (string, error) {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return "", errors.New("Cannot scan dir for specfile: " + dir)
@@ -119,18 +119,18 @@ func RpmFindSpec(dir string) (string, error) {
 
 // Using the first specfile found, parse it's fields and return an struct
 // allowing easy asccess to fields.
-func RpmFindAndParseSpec(dir string) (RpmSpec, error) {
-	specfile, err := RpmFindSpec(dir)
+func rpmFindAndParseSpec(dir string) (RpmSpec, error) {
+	specfile, err := rpmFindSpec(dir)
 	if err != nil {
 		return RpmSpec{}, err
 	}
 
-	spec, err := RpmParseSpec(specfile)
+	spec, err := rpmParseSpec(specfile)
 	return spec, err
 }
 
 // Given a specfile parse and return fields from the file
-func RpmParseSpec(name string) (RpmSpec, error) {
+func rpmParseSpec(name string) (RpmSpec, error) {
 	if !util.Exists(name) {
 		return RpmSpec{}, errors.New("File: " + name + " not found")
 	}
@@ -145,7 +145,7 @@ func RpmParseSpec(name string) (RpmSpec, error) {
 	out, err := exec.Command("rpmspec", "-P", name).Output()
 	if err != nil {
 		// rpmspec will occasionally return errors, so ignore them
-		log.Printf("RpmParseSpec: ignoring error %s", err.Error())
+		log.Printf("rpmParseSpec: ignoring error %s", err.Error())
 		// return RpmSpec{}, err
 	}
 
@@ -166,7 +166,7 @@ func RpmParseSpec(name string) (RpmSpec, error) {
 }
 
 // Using a rpmspec obj return source0. Could be called Source0, or Source
-func (rpm RpmSpec) RpmGetSource0() (string, error) {
+func (rpm RpmSpec) GetSource0() (string, error) {
 	if rpm.Tags["sources"] == nil {
 		return "", errors.New("no sources")
 	}
@@ -186,21 +186,17 @@ func (rpm RpmSpec) RpmGetSource0() (string, error) {
 
 // Using an rpmspec obj (rpm.spec location) and an output location, extract
 // the source rpm and apply patches
-func (rpm RpmSpec) RpmApplyPatches() error {
-	if !strings.HasSuffix(rpm.SourcesLocation, "SOURCES") {
-		return errors.New("RpmApplyPatches: expected SOURCES path is incorrect: " + rpm.SourcesLocation)
-	}
+func (rpm RpmSpec) ApplyPatches() error {
 	cmd := exec.Command("bash", "-c", "rpmbuild -bp --nodeps --define \"_topdir "+rpm.OutLocation+" \" "+rpm.SpecLocation)
-
 	if err := cmd.Run(); err != nil {
-		return errors.New("RpmApplyPatches: failed to run rpmbuild: " + err.Error())
+		return errors.New("ApplyPatches: failed to run rpmbuild: " + err.Error())
 	}
 
 	return nil
 }
 
 // Best effort removal of src rpm files.
-func (rpm RpmSpec) RpmCleanup() {
+func (rpm RpmSpec) Cleanup() {
 	os.RemoveAll(rpm.SourcesLocation)
 	os.RemoveAll(rpm.SrpmLocation)
 	os.RemoveAll(rpm.BuildLocation)
@@ -224,7 +220,7 @@ func RpmSpecFromFile(filePath string, outputPath string) (RpmSpec, error) {
 		return RpmSpec{}, errors.New("failed to unpack rpm file")
 	}
 
-	rpmSpec, err := RpmFindAndParseSpec(sourcesDir)
+	rpmSpec, err := rpmFindAndParseSpec(sourcesDir)
 	if err != nil {
 		return RpmSpec{}, errors.New("failed to parse specfile: " + err.Error())
 	}

--- a/rpmtools.go
+++ b/rpmtools.go
@@ -20,12 +20,16 @@ import (
 // SpecTag structs so help easily reference values, for example
 // RpmSpec.Tags["url"].
 type RpmSpec struct {
-	SpecLocation    string
-	SrpmLocation    string
-	SourcesLocation string
-	OutLocation     string
-	BuildLocation   string
-	Tags            map[string][]SpecTag
+	SpecLocation      string
+	SrpmLocation      string
+	SourcesLocation   string
+	OutLocation       string
+	BuildLocation     string
+	Tags              map[string][]SpecTag
+	SourcesTags       []SpecTag
+	PatchTags         []SpecTag
+	BuildRequiresTags []SpecTag
+	RequiresTags      []SpecTag
 }
 
 // Represents a row/field of key name + key value within a specfile
@@ -162,16 +166,20 @@ func rpmParseSpec(name string) (RpmSpec, error) {
 			}
 		}
 	}
+	rpm.SourcesTags = rpm.Tags["sources"]
+	rpm.PatchTags = rpm.Tags["patches"]
+	rpm.BuildRequiresTags = rpm.Tags["buildRequires"]
+	rpm.RequiresTags = rpm.Tags["requires"]
 	return rpm, nil
 }
 
 // Using a rpmspec obj return source0. Could be called Source0, or Source
 func (rpm RpmSpec) GetSource0() (string, error) {
-	if rpm.Tags["sources"] == nil {
+	if rpm.SourcesTags == nil {
 		return "", errors.New("no sources")
 	}
 
-	for _, source := range rpm.Tags["sources"] {
+	for _, source := range rpm.SourcesTags {
 		switch source.TagName {
 		case "Source0":
 			fallthrough
@@ -181,7 +189,7 @@ func (rpm RpmSpec) GetSource0() (string, error) {
 	}
 
 	// don't find any? we can only assume the first value
-	return rpm.Tags["sources"][0].TagValue, nil
+	return rpm.SourcesTags[0].TagValue, nil
 }
 
 // Using an rpmspec obj (rpm.spec location) and an output location, extract

--- a/rpmtools_test.go
+++ b/rpmtools_test.go
@@ -1,0 +1,135 @@
+package rpmtools
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+type test struct {
+	url        string
+	specName   string
+	sourceTags []string
+	patchTags  []string
+}
+
+var outDir string
+
+var tests = []test{
+	{
+		"https://kojipkgs.fedoraproject.org//packages/python-urllib3/1.25.8/5.fc33/src/python-urllib3-1.25.8-5.fc33.src.rpm",
+		"python-urllib3.spec",
+		[]string{"https://github.com/urllib3/urllib3/archive/1.25.8/urllib3-1.25.8.tar.gz", "ssl_match_hostname_py3.py"},
+		[]string{"CVE-2021-33503.patch"},
+	},
+	{
+		"https://kojipkgs.fedoraproject.org//packages/rizin/0.2.0/2.fc33/src/rizin-0.2.0-2.fc33.src.rpm",
+		"rizin.spec",
+		[]string{"https://github.com/rizinorg/rizin/releases/download/v0.2.0/rizin-src-v0.2.0.tar.xz"},
+		[]string{"rizin-avoid-symbols-clashing.patch"},
+	},
+}
+
+func SortCompare(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	sort.Strings(a)
+	sort.Strings(b)
+
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestMain(m *testing.M) {
+	var err error
+	outDir, err = ioutil.TempDir("", "")
+	if err != nil {
+		return
+	}
+	m.Run()
+	os.Remove(outDir)
+}
+
+func TestRpmSpecFromFile(t *testing.T) {
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("url=%s", test.url), func(t *testing.T) {
+			url := test.url
+			resp, err := http.Get(url)
+			if err != nil {
+				t.Error(err)
+			}
+			defer resp.Body.Close()
+
+			out, err := ioutil.TempFile("", "")
+			if err != nil {
+				t.Error(err)
+			}
+			defer out.Close()
+
+			_, err = io.Copy(out, resp.Body)
+			if err != nil {
+				t.Error(err)
+			}
+
+			rpmSpec, err := RpmSpecFromFile(out.Name(), outDir)
+			if err != nil {
+				t.Error(err)
+			}
+
+			sourcesLocationExp := filepath.Join(outDir, "SOURCES")
+			srpmLocationExp := filepath.Join(outDir, "SRPMS")
+			buildLocationExp := filepath.Join(outDir, "BUILD")
+			outLocationExp := outDir
+			if rpmSpec.SourcesLocation != sourcesLocationExp {
+				t.Errorf("SourcesLocation is wrong: %s, exp: %s", rpmSpec.SourcesLocation, sourcesLocationExp)
+			}
+			if rpmSpec.SrpmLocation != srpmLocationExp {
+				t.Errorf("SRPMLocation is wrong: %s, exp: %s", rpmSpec.SrpmLocation, srpmLocationExp)
+			}
+			if rpmSpec.BuildLocation != buildLocationExp {
+				t.Errorf("BuildLocation is wrong: %s, exp: %s", rpmSpec.SrpmLocation, buildLocationExp)
+			}
+			if rpmSpec.OutLocation != outLocationExp {
+				t.Errorf("OutLocation is wrong: %s, exp: %s", rpmSpec.SrpmLocation, buildLocationExp)
+			}
+			if filepath.Base(rpmSpec.SpecLocation) != test.specName {
+				t.Errorf("Spec file was wrongly detected: %s, exp: %s", filepath.Base(rpmSpec.SpecLocation), test.specName)
+			}
+
+			source0, err := rpmSpec.RpmGetSource0()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if source0 != test.sourceTags[0] {
+				t.Errorf("Source0 was not correctly found: %s, exp: %s", source0, test.sourceTags[0])
+			}
+
+			sourcesTags := make([]string, len(rpmSpec.Tags["sources"]))
+			for i, s := range rpmSpec.Tags["sources"] {
+				sourcesTags[i] = s.TagValue
+			}
+			if !SortCompare(sourcesTags, test.sourceTags) {
+				t.Errorf("Sources tags are wrong: %v, exp: %v", sourcesTags, test.sourceTags)
+			}
+
+			patchesTags := make([]string, len(rpmSpec.Tags["patches"]))
+			for i, s := range rpmSpec.Tags["patches"] {
+				patchesTags[i] = s.TagValue
+			}
+			if !SortCompare(patchesTags, test.patchTags) {
+				t.Errorf("Patch tags are wrong: %v, exp: %v", patchesTags, test.patchTags)
+			}
+		})
+	}
+}

--- a/rpmtools_test.go
+++ b/rpmtools_test.go
@@ -51,6 +51,18 @@ func SortCompare(a []string, b []string) bool {
 	return true
 }
 
+func equalSpecTags(a, b []SpecTag) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestMain(m *testing.M) {
 	var err error
 	outDir, err = ioutil.TempDir("", "")
@@ -115,16 +127,26 @@ func TestRpmSpecFromFile(t *testing.T) {
 				t.Errorf("Source0 was not correctly found: %s, exp: %s", source0, test.sourceTags[0])
 			}
 
-			sourcesTags := make([]string, len(rpmSpec.Tags["sources"]))
-			for i, s := range rpmSpec.Tags["sources"] {
+			if !equalSpecTags(rpmSpec.Tags["sources"], rpmSpec.SourcesTags) {
+				t.Errorf("tags['sources'] different from SourcesTags")
+			}
+			if !equalSpecTags(rpmSpec.Tags["patches"], rpmSpec.PatchTags) {
+				t.Errorf("tags['patches'] different from PatchTags")
+			}
+			if !equalSpecTags(rpmSpec.Tags["requires"], rpmSpec.RequiresTags) {
+				t.Errorf("tags['requires'] different from RequiresTags")
+			}
+
+			sourcesTags := make([]string, len(rpmSpec.SourcesTags))
+			for i, s := range rpmSpec.SourcesTags {
 				sourcesTags[i] = s.TagValue
 			}
 			if !SortCompare(sourcesTags, test.sourceTags) {
 				t.Errorf("Sources tags are wrong: %v, exp: %v", sourcesTags, test.sourceTags)
 			}
 
-			patchesTags := make([]string, len(rpmSpec.Tags["patches"]))
-			for i, s := range rpmSpec.Tags["patches"] {
+			patchesTags := make([]string, len(rpmSpec.PatchTags))
+			for i, s := range rpmSpec.PatchTags {
 				patchesTags[i] = s.TagValue
 			}
 			if !SortCompare(patchesTags, test.patchTags) {

--- a/rpmtools_test.go
+++ b/rpmtools_test.go
@@ -107,7 +107,7 @@ func TestRpmSpecFromFile(t *testing.T) {
 				t.Errorf("Spec file was wrongly detected: %s, exp: %s", filepath.Base(rpmSpec.SpecLocation), test.specName)
 			}
 
-			source0, err := rpmSpec.RpmGetSource0()
+			source0, err := rpmSpec.GetSource0()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -130,6 +130,8 @@ func TestRpmSpecFromFile(t *testing.T) {
 			if !SortCompare(patchesTags, test.patchTags) {
 				t.Errorf("Patch tags are wrong: %v, exp: %v", patchesTags, test.patchTags)
 			}
+
+			rpmSpec.Cleanup()
 		})
 	}
 }


### PR DESCRIPTION
This way we don't have to change rpmtools if we change the way the SRPM
file is retrieved (e.g. if the file is already downloaded or is
downloaded through ftp:// or other protocols).

* Add tests in rpmtools_test.go



We can easily extend the tests to start covering more tricky usecases.