### PR TITLE
rpmbuild: handle when succeed, but the BUILD dir is empty

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -62,4 +63,19 @@ func CreateRpmBuildStructure(output string) (string, string, string, error) {
 	}
 
 	return sourceRPM, sRPM, bRPM, nil
+}
+
+func DirEmpty(loc string) error {
+	f, err := os.Open(loc)
+	if err != nil {
+		return errors.New("ApplyPatches: failed to open output location: " + loc)
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return errors.New("ApplyPatches: dir is empty: " + loc)
+	}
+
+	return nil
 }

--- a/rpmtools.go
+++ b/rpmtools.go
@@ -225,6 +225,11 @@ func (rpm RpmSpec) ApplyPatches() error {
 		return errors.New("ApplyPatches: failed to run rpmbuild: " + err.Error())
 	}
 
+	// test if rpmbuild "passed", but didn't do anything, that's a fail if empty
+	if err := util.DirEmpty(rpm.BuildLocation); err != nil {
+		return errors.New("ApplyPatches: BUILD dir is empty: " + err.Error())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Found that occasionally, `rpmbuild` would succeed in prep but if the rpm spec didn't specify anything this lead to undesired behavior. If nothing get's output input the BUILD dir, assume failure or apply patches